### PR TITLE
Fix conflict between C & Clojure

### DIFF
--- a/grammars/gfm.cson
+++ b/grammars/gfm.cson
@@ -607,7 +607,7 @@
     ]
   }
   {
-    'begin': '^\\s*([`~]{3,})\\{?\\s*(?i:(c))[\\s\\S]*?\\}?\\s*$'
+    'begin': '^\\s*([`~]{3,})\\{?\\s*(?i:(c)(?!l[ojure]+))[\\s\\S]*?\\}?\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'
@@ -1038,7 +1038,7 @@
     ]
   },
   {
-    'begin': '^\\s*([`~]{3,})\\{?\\s*(?i:(clojure))[\\s\\S]*?\\}?\\s*$'
+    'begin': '^\\s*([`~]{3,})\\{?\\s*(?i:(clojure|clj))[\\s\\S]*?\\}?\\s*$'
     'beginCaptures':
       '0':
         'name': 'support.gfm'


### PR DESCRIPTION
The previous regex to permit info strings at the beginning of code fences made the grammar parse `clojure` as `c`. I have edited the regex to properly distinguish `c` and `clojure` (without breaking info strings for `c` code fences). Also added support for `clj` tag.